### PR TITLE
Support Prometheus metrics directly

### DIFF
--- a/metrics/prometheus/cache.go
+++ b/metrics/prometheus/cache.go
@@ -42,7 +42,7 @@ func (c *vectorCache) getOrMakeCounterVec(opts prometheus.CounterOpts, labelName
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	cacheKey := strings.Join(append([]string{opts.Name}, labelNames...), "||")
+	cacheKey := c.getCacheKey(opts.Name, labelNames)
 	cv, cvExists := c.cVecs[cacheKey]
 	if !cvExists {
 		cv = prometheus.NewCounterVec(opts, labelNames)
@@ -56,7 +56,7 @@ func (c *vectorCache) getOrMakeGaugeVec(opts prometheus.GaugeOpts, labelNames []
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	cacheKey := strings.Join(append([]string{opts.Name}, labelNames...), "||")
+	cacheKey := c.getCacheKey(opts.Name, labelNames)
 	gv, gvExists := c.gVecs[cacheKey]
 	if !gvExists {
 		gv = prometheus.NewGaugeVec(opts, labelNames)
@@ -70,7 +70,7 @@ func (c *vectorCache) getOrMakeHistogramVec(opts prometheus.HistogramOpts, label
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	cacheKey := strings.Join(append([]string{opts.Name}, labelNames...), "||")
+	cacheKey := c.getCacheKey(opts.Name, labelNames)
 	hv, hvExists := c.hVecs[cacheKey]
 	if !hvExists {
 		hv = prometheus.NewHistogramVec(opts, labelNames)
@@ -78,4 +78,8 @@ func (c *vectorCache) getOrMakeHistogramVec(opts prometheus.HistogramOpts, label
 		c.hVecs[cacheKey] = hv
 	}
 	return hv
+}
+
+func (c *vectorCache) getCacheKey(name string, labels []string) string {
+	return strings.Join(append([]string{name}, labels...), "||")
 }

--- a/metrics/prometheus/cache.go
+++ b/metrics/prometheus/cache.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2017 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type vectorCache struct {
+	registerer prometheus.Registerer
+	lock       sync.Mutex
+	cVecs      map[string]*prometheus.CounterVec
+	gVecs      map[string]*prometheus.GaugeVec
+	hVecs      map[string]*prometheus.HistogramVec
+}
+
+func newVectorCache(registerer prometheus.Registerer) *vectorCache {
+	return &vectorCache{
+		registerer: registerer,
+		cVecs:      make(map[string]*prometheus.CounterVec),
+		gVecs:      make(map[string]*prometheus.GaugeVec),
+		hVecs:      make(map[string]*prometheus.HistogramVec),
+	}
+}
+
+func (c *vectorCache) getOrMakeCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	cacheKey := strings.Join(append([]string{opts.Name}, labelNames...), "||")
+	cv, cvExists := c.cVecs[cacheKey]
+	if !cvExists {
+		cv = prometheus.NewCounterVec(opts, labelNames)
+		c.registerer.MustRegister(cv)
+		c.cVecs[cacheKey] = cv
+	}
+	return cv
+}
+
+func (c *vectorCache) getOrMakeGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	cacheKey := strings.Join(append([]string{opts.Name}, labelNames...), "||")
+	gv, gvExists := c.gVecs[cacheKey]
+	if !gvExists {
+		gv = prometheus.NewGaugeVec(opts, labelNames)
+		c.registerer.MustRegister(gv)
+		c.gVecs[cacheKey] = gv
+	}
+	return gv
+}
+
+func (c *vectorCache) getOrMakeHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	cacheKey := strings.Join(append([]string{opts.Name}, labelNames...), "||")
+	hv, hvExists := c.hVecs[cacheKey]
+	if !hvExists {
+		hv = prometheus.NewHistogramVec(opts, labelNames)
+		c.registerer.MustRegister(hv)
+		c.hVecs[cacheKey] = hv
+	}
+	return hv
+}

--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -56,11 +56,11 @@ func newFactory(cache *vectorCache, scope string, tags map[string]string, bucket
 func (f *Factory) Counter(name string, tags map[string]string) metrics.Counter {
 	name = f.subScope(name)
 	tags = f.mergeTags(tags)
+	labelNames := f.tagNames(tags)
 	opts := prometheus.CounterOpts{
 		Name: name,
 		Help: name,
 	}
-	labelNames := f.tagNames(tags)
 	cv := f.cache.getOrMakeCounterVec(opts, labelNames)
 	return &counter{
 		counter: cv.WithLabelValues(f.tagsAsLabelValues(labelNames, tags)...),
@@ -71,11 +71,11 @@ func (f *Factory) Counter(name string, tags map[string]string) metrics.Counter {
 func (f *Factory) Gauge(name string, tags map[string]string) metrics.Gauge {
 	name = f.subScope(name)
 	tags = f.mergeTags(tags)
+	labelNames := f.tagNames(tags)
 	opts := prometheus.GaugeOpts{
 		Name: name,
 		Help: name,
 	}
-	labelNames := f.tagNames(tags)
 	gv := f.cache.getOrMakeGaugeVec(opts, labelNames)
 	return &gauge{
 		gauge: gv.WithLabelValues(f.tagsAsLabelValues(labelNames, tags)...),
@@ -86,12 +86,12 @@ func (f *Factory) Gauge(name string, tags map[string]string) metrics.Gauge {
 func (f *Factory) Timer(name string, tags map[string]string) metrics.Timer {
 	name = f.subScope(name)
 	tags = f.mergeTags(tags)
+	labelNames := f.tagNames(tags)
 	opts := prometheus.HistogramOpts{
 		Name:    name,
 		Help:    name,
 		Buckets: f.buckets,
 	}
-	labelNames := f.tagNames(tags)
 	hv := f.cache.getOrMakeHistogramVec(opts, labelNames)
 	return &timer{
 		histogram: hv.WithLabelValues(f.tagsAsLabelValues(labelNames, tags)...),

--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -24,7 +24,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 )
 
-// Factory implements metrics.Factory backed my Prometheus registry.
+// Factory implements metrics.Factory backed by Prometheus registry.
 type Factory struct {
 	scope      string
 	tags       map[string]string

--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2017 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+type Factory struct {
+	registerer prometheus.Registerer
+	scope      string
+	tags       map[string]string
+	cVecs      map[string]*prometheus.CounterVec
+	lock       sync.Mutex
+}
+
+func New(registerer prometheus.Registerer) *Factory {
+	return newFactory(registerer, "", nil)
+}
+
+func newFactory(registerer prometheus.Registerer, scope string, tags map[string]string) *Factory {
+	return &Factory{
+		registerer: registerer,
+		scope:      scope,
+		tags:       tags,
+		cVecs:      make(map[string]*prometheus.CounterVec),
+	}
+}
+
+// Counter implements Counter of metrics.Factory.
+func (f *Factory) Counter(name string, tags map[string]string) metrics.Counter {
+	name = f.subScope(name)
+	tags = f.mergeTags(tags)
+	opts := prometheus.CounterOpts{
+		Name: name,
+		Help: name,
+	}
+	labelNames := f.tagNames(tags)
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	cacheKey := strings.Join(append([]string{name}, labelNames...), "||")
+	cv, cvExists := f.cVecs[cacheKey]
+	if !cvExists {
+		cv = prometheus.NewCounterVec(opts, labelNames)
+		f.registerer.MustRegister(cv)
+		f.cVecs[cacheKey] = cv
+	}
+	return &counter{
+		counter: cv.WithLabelValues(f.tagsAsLabelValues(labelNames, tags)...),
+	}
+}
+
+type counter struct {
+	counter prometheus.Counter
+}
+
+func (c *counter) Inc(v int64) {
+	c.counter.Add(float64(v))
+}
+
+func (f *Factory) Timer(name string, tags map[string]string) metrics.Timer { return nil }
+
+func (f *Factory) Gauge(name string, tags map[string]string) metrics.Gauge { return nil }
+
+func (f *Factory) Namespace(name string, tags map[string]string) metrics.Factory {
+	return newFactory(f.registerer, f.subScope(name), f.mergeTags(tags))
+}
+
+func (f *Factory) subScope(name string) string {
+	if f.scope == "" {
+		return name
+	}
+	if name == "" {
+		return f.scope
+	}
+	return f.scope + ":" + name
+}
+
+func (f *Factory) mergeTags(tags map[string]string) map[string]string {
+	ret := make(map[string]string, len(f.tags)+len(tags))
+	for k, v := range f.tags {
+		ret[k] = v
+	}
+	for k, v := range tags {
+		ret[k] = v
+	}
+	return ret
+}
+
+func (f *Factory) tagNames(tags map[string]string) []string {
+	ret := make([]string, 0, len(tags))
+	for k := range tags {
+		ret = append(ret, k)
+	}
+	sort.Strings(ret)
+	return ret
+}
+
+func (f *Factory) tagsAsLabelValues(labels []string, tags map[string]string) []string {
+	ret := make([]string, 0, len(tags))
+	for _, l := range labels {
+		if v, ok := tags[l]; ok {
+			ret = append(ret, v)
+		} else {
+			ret = append(ret, "")
+		}
+	}
+	return ret
+}

--- a/metrics/prometheus/factory_test.go
+++ b/metrics/prometheus/factory_test.go
@@ -120,17 +120,18 @@ func TestTimer(t *testing.T) {
 	}
 }
 
-func TestTimerCustomBuckts(t *testing.T) {
+func TestTimerCustomBuckets(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
 	f1 := New(registry, []float64{1.5})
-	t1 := f1.Timer("bender:rodriguez", map[string]string{"x": "y"})
+	// dot and dash in the metric name will be replaced with underscore
+	t1 := f1.Timer("bender.bending-rodriguez", map[string]string{"x": "y"})
 	t1.Record(1 * time.Second)
 	t1.Record(2 * time.Second)
 
 	snapshot, err := registry.Gather()
 	require.NoError(t, err)
 
-	m1 := findMetric(t, snapshot, "bender:rodriguez", map[string]string{"x": "y"})
+	m1 := findMetric(t, snapshot, "bender_bending_rodriguez", map[string]string{"x": "y"})
 	assert.EqualValues(t, 2, m1.GetHistogram().GetSampleCount(), "%+v", m1)
 	assert.EqualValues(t, 3, m1.GetHistogram().GetSampleSum(), "%+v", m1)
 	assert.Len(t, m1.GetHistogram().GetBucket(), 1)

--- a/metrics/prometheus/factory_test.go
+++ b/metrics/prometheus/factory_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2017 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promModel "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+var _ metrics.Factory = new(Factory)
+
+func TestCounter(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	f1 := New(registry)
+	f2 := f1.Namespace("bender", map[string]string{"a": "b"})
+	c1 := f2.Counter("rodriguez", map[string]string{"x": "y"})
+	c2 := f2.Counter("rodriguez", map[string]string{"x": "z"})
+	c1.Inc(1)
+	c1.Inc(2)
+	c2.Inc(3)
+	c2.Inc(4)
+
+	snapshot, err := registry.Gather()
+	require.NoError(t, err)
+
+	m1 := findMetric(t, snapshot, "bender:rodriguez", map[string]string{"a": "b", "x": "y"})
+	assert.EqualValues(t, 3, m1.GetCounter().GetValue())
+
+	m2 := findMetric(t, snapshot, "bender:rodriguez", map[string]string{"a": "b", "x": "z"})
+	assert.EqualValues(t, 7, m2.GetCounter().GetValue(), "%+v", m2)
+}
+
+func findMetric(t *testing.T, snapshot []*promModel.MetricFamily, name string, tags map[string]string) *promModel.Metric {
+	for _, mf := range snapshot {
+		if mf.GetName() == name {
+			for _, m := range mf.GetMetric() {
+				if len(m.GetLabel()) != len(tags) {
+					t.Fatalf("Mismatching labels for metric %v: want %v, have %v", name, tags, m.GetLabel())
+				}
+				match := true
+				for _, l := range m.GetLabel() {
+					if v, ok := tags[l.GetName()]; !ok || v != l.GetValue() {
+						match = false
+					}
+				}
+				if match {
+					return m
+				}
+			}
+		}
+	}
+	t.Logf("Cannot find metric %v %v", name, tags)
+	for _, nf := range snapshot {
+		t.Logf("Family: %v", nf.GetName())
+		for _, m := range nf.GetMetric() {
+			t.Logf("==> %v", m)
+		}
+	}
+	t.FailNow()
+	return nil
+}


### PR DESCRIPTION
Required by https://github.com/jaegertracing/jaeger/issues/360 and https://github.com/jaegertracing/jaeger/issues/273

Prometheus requires pre-declaring all metrics and their labels, and for a given metric name only one set of labels is allowed, otherwise panic occurs.

The approach here is to cache metric vectors registered with Prometheus using metric's name and a sorted list of labels as the cache key. This allows creating Jaeger metrics objects multiple times even with the same name and a set of tags.
