### PR TITLE
Change org in imported modules from uber to jaegertracing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 language: go
-go_import_path: github.com/uber/jaeger-lib
+go_import_path: github.com/jaegertracing/jaeger-lib
 
 go:
   - 1.7

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_ROOT=github.com/uber/jaeger-lib
+PROJECT_ROOT=github.com/jaegertracing/jaeger-lib
 PACKAGES := $(shell glide novendor | grep -v ./thrift-gen/...)
 # all .go files that don't exist in hidden directories
 ALL_SRC := $(shell find . -name "*.go" | grep -v -e vendor -e thrift-gen \

--- a/client/log/go-kit/logger.go
+++ b/client/log/go-kit/logger.go
@@ -53,12 +53,12 @@ func NewLogger(kitlogger log.Logger, options ...LoggerOption) *Logger {
 	return logger
 }
 
-// Error implements the github.com/uber/jaeger-client-go/log.Logger interface.
+// Error implements the github.com/jaegertracing/jaeger-client-go/log.Logger interface.
 func (l *Logger) Error(msg string) {
 	l.errorLogger.Log(l.messageKey, msg)
 }
 
-// Infof implements the github.com/uber/jaeger-client-go/log.Logger interface.
+// Infof implements the github.com/jaegertracing/jaeger-client-go/log.Logger interface.
 func (l *Logger) Infof(msg string, args ...interface{}) {
 	l.infoLogger.Log(l.messageKey, fmt.Sprintf(msg, args...))
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/uber/jaeger-lib
+package: github.com/jaegertracing/jaeger-lib
 import:
 - package: github.com/codahale/hdrhistogram
 - package: github.com/go-kit/kit

--- a/metrics/go-kit/expvar/factory.go
+++ b/metrics/go-kit/expvar/factory.go
@@ -18,7 +18,7 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/expvar"
 
-	"github.com/uber/jaeger-lib/metrics/go-kit"
+	"github.com/jaegertracing/jaeger-lib/metrics/go-kit"
 )
 
 // NewFactory creates a new metrics factory using go-kit expvar package.

--- a/metrics/go-kit/factory.go
+++ b/metrics/go-kit/factory.go
@@ -17,7 +17,7 @@ package xkit
 import (
 	kit "github.com/go-kit/kit/metrics"
 
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/jaegertracing/jaeger-lib/metrics"
 )
 
 // Factory provides a unified interface for creating named metrics

--- a/metrics/go-kit/factory_test.go
+++ b/metrics/go-kit/factory_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-kit/kit/metrics/generic"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/jaegertracing/jaeger-lib/metrics"
 )
 
 type genericFactory struct{}

--- a/metrics/go-kit/influx/factory.go
+++ b/metrics/go-kit/influx/factory.go
@@ -18,7 +18,7 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/influx"
 
-	"github.com/uber/jaeger-lib/metrics/go-kit"
+	"github.com/jaegertracing/jaeger-lib/metrics/go-kit"
 )
 
 // NewFactory creates a new metrics factory using go-kit influx package.

--- a/metrics/go-kit/influx/factory_test.go
+++ b/metrics/go-kit/influx/factory_test.go
@@ -11,7 +11,7 @@ import (
 	influxdb "github.com/influxdata/influxdb/client/v2"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/uber/jaeger-lib/metrics/go-kit"
+	"github.com/jaegertracing/jaeger-lib/metrics/go-kit"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/go-kit/metrics_test.go
+++ b/metrics/go-kit/metrics_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-kit/kit/metrics/generic"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/jaegertracing/jaeger-lib/metrics"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/go-kit/prometheus/factory.go
+++ b/metrics/go-kit/prometheus/factory.go
@@ -21,7 +21,7 @@ import (
 	kitprom "github.com/go-kit/kit/metrics/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/uber/jaeger-lib/metrics/go-kit"
+	"github.com/jaegertracing/jaeger-lib/metrics/go-kit"
 )
 
 var normalizer = strings.NewReplacer(

--- a/metrics/go-kit/prometheus/factory_test.go
+++ b/metrics/go-kit/prometheus/factory_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	xkit "github.com/uber/jaeger-lib/metrics/go-kit"
+	xkit "github.com/jaegertracing/jaeger-lib/metrics/go-kit"
 )
 
 func TestCounter(t *testing.T) {

--- a/metrics/multi/multi.go
+++ b/metrics/multi/multi.go
@@ -17,7 +17,7 @@ package multi
 import (
 	"time"
 
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/jaegertracing/jaeger-lib/metrics"
 )
 
 // Factory is a metrics factory that dispatches to multiple metrics backends.

--- a/metrics/multi/multi_test.go
+++ b/metrics/multi/multi_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jaegertracing/jaeger-lib/metrics"
+	"github.com/jaegertracing/jaeger-lib/metrics/testutils"
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
 )
 
 var _ metrics.Factory = &Factory{} // API check

--- a/metrics/tally/factory.go
+++ b/metrics/tally/factory.go
@@ -17,7 +17,7 @@ package tally
 import (
 	"github.com/uber-go/tally"
 
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/jaegertracing/jaeger-lib/metrics"
 )
 
 // Wrap takes a tally Scope and returns jaeger-lib metrics.Factory.

--- a/metrics/testutils/testutils.go
+++ b/metrics/testutils/testutils.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/jaegertracing/jaeger-lib/metrics"
 )
 
 // ExpectedMetric contains metrics under test.

--- a/metrics/testutils/testutils_test.go
+++ b/metrics/testutils/testutils_test.go
@@ -3,7 +3,7 @@ package testutils
 import (
 	"testing"
 
-	"github.com/uber/jaeger-lib/metrics"
+	"github.com/jaegertracing/jaeger-lib/metrics"
 )
 
 func TestAssertMetrics(t *testing.T) {

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -3,7 +3,7 @@
 set -e
 
 COVER=.cover
-ROOT_PKG=github.com/uber/jaeger-lib/
+ROOT_PKG=github.com/jaegertracing/jaeger-lib/
 
 if [[ -d "$COVER" ]]; then
 	rm -rf "$COVER"


### PR DESCRIPTION
Following on from the move of the repo from uber org to jaegertracing. Once merged, will update jaeger-client-go and then jaeger to also reference the new locations.

Signed-off-by: Gary Brown <gary@brownuk.com>