### PR TITLE
Change prometheus.New() to accept options rather than fixed arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes by Version
 1.2.1 (unreleased)
 ------------------
 
-- Nothing yet.
+- *breaking* Change prometheus.New() to accept options instead of fixed arguments
 
 
 1.2.0 (2017-11-12)

--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -38,7 +38,7 @@ type options struct {
 	buckets    []float64
 }
 
-// Option  is a function that sets some option for the Factory constructor.
+// Option is a function that sets some option for the Factory constructor.
 type Option func(*options)
 
 // WithRegisterer returns an option that sets the registerer.

--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -33,6 +33,41 @@ type Factory struct {
 	normalizer *strings.Replacer
 }
 
+type options struct {
+	registerer prometheus.Registerer
+	buckets    []float64
+}
+
+// Option  is a function that sets some option for the Factory constructor.
+type Option func(*options)
+
+// WithRegisterer returns an option that sets the registerer.
+// If not used we fallback to prometheus.DefaultRegisterer.
+func WithRegisterer(registerer prometheus.Registerer) Option {
+	return func(opts *options) {
+		opts.registerer = registerer
+	}
+}
+
+// WithBuckets returns an option that sets the default buckets for histogram.
+// If not used, we fallback to default Prometheus buckets.
+func WithBuckets(buckets []float64) Option {
+	return func(opts *options) {
+		opts.buckets = buckets
+	}
+}
+
+func applyOptions(opts []Option) *options {
+	options := new(options)
+	for _, o := range opts {
+		o(options)
+	}
+	if options.registerer == nil {
+		options.registerer = prometheus.DefaultRegisterer
+	}
+	return options
+}
+
 // New creates a Factory backed by Prometheus registry.
 // Typically the first argument should be prometheus.DefaultRegisterer.
 //
@@ -41,15 +76,16 @@ type Factory struct {
 // values must be sorted in strictly increasing order. There is no need
 // to add a highest bucket with +Inf bound, it will be added
 // implicitly. The default value is prometheus.DefBuckets.
-func New(registerer prometheus.Registerer, buckets []float64) *Factory {
+func New(opts ...Option) *Factory {
+	options := applyOptions(opts)
 	return newFactory(
 		&Factory{ // dummy struct to be discarded
-			cache:      newVectorCache(registerer),
-			buckets:    buckets,
+			cache:      newVectorCache(options.registerer),
+			buckets:    options.buckets,
 			normalizer: strings.NewReplacer(".", "_", "-", "_"),
 		},
-		"",
-		nil)
+		"",  // scope
+		nil) // tags
 }
 
 func newFactory(parent *Factory, scope string, tags map[string]string) *Factory {

--- a/metrics/prometheus/factory_test.go
+++ b/metrics/prometheus/factory_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package prometheus
+package prometheus_test
 
 import (
 	"testing"
@@ -24,17 +24,22 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/uber/jaeger-lib/metrics"
+	. "github.com/uber/jaeger-lib/metrics/prometheus"
 )
 
 var _ metrics.Factory = new(Factory)
 
+func TestOptions(t *testing.T) {
+	f1 := New()
+	assert.NotNil(t, f1)
+}
+
 func TestCounter(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
-	f1 := New(registry, nil)
+	f1 := New(WithRegisterer(registry))
 	fDummy := f1.Namespace("", nil)
 	f2 := fDummy.Namespace("bender", map[string]string{"a": "b"})
 	f3 := f2.Namespace("", nil)
-	assert.Equal(t, "bender", f3.(*Factory).scope)
 
 	c1 := f2.Counter("rodriguez", map[string]string{"x": "y"})
 	c2 := f2.Counter("rodriguez", map[string]string{"x": "z"})
@@ -56,7 +61,7 @@ func TestCounter(t *testing.T) {
 
 func TestGauge(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
-	f1 := New(registry, nil)
+	f1 := New(WithRegisterer(registry))
 	f2 := f1.Namespace("bender", map[string]string{"a": "b"})
 	f3 := f2.Namespace("", map[string]string{"a": "b"}) // essentially same as f2
 	g1 := f2.Gauge("rodriguez", map[string]string{"x": "y"})
@@ -79,7 +84,7 @@ func TestGauge(t *testing.T) {
 
 func TestTimer(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
-	f1 := New(registry, nil)
+	f1 := New(WithRegisterer(registry))
 	f2 := f1.Namespace("bender", map[string]string{"a": "b"})
 	f3 := f2.Namespace("", map[string]string{"a": "b"}) // essentially same as f2
 	t1 := f2.Timer("rodriguez", map[string]string{"x": "y"})
@@ -122,7 +127,7 @@ func TestTimer(t *testing.T) {
 
 func TestTimerCustomBuckets(t *testing.T) {
 	registry := prometheus.NewPedanticRegistry()
-	f1 := New(registry, []float64{1.5})
+	f1 := New(WithRegisterer(registry), WithBuckets([]float64{1.5}))
 	// dot and dash in the metric name will be replaced with underscore
 	t1 := f1.Timer("bender.bending-rodriguez", map[string]string{"x": "y"})
 	t1.Record(1 * time.Second)


### PR DESCRIPTION
This is a breaking change, but I don't suppose anyone had a change to use the new `prometheus.New()` API that was only released 2d ago.
