### PR TITLE
Reimplement expvar metrics to be tolerant of duplicates

### DIFF
--- a/metrics/adapters/cache.go
+++ b/metrics/adapters/cache.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import (
+	"sync"
+
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+type cache struct {
+	lock     sync.Mutex
+	counters map[string]metrics.Counter
+	gauges   map[string]metrics.Gauge
+	timers   map[string]metrics.Timer
+}
+
+func newCache() *cache {
+	return &cache{
+		counters: make(map[string]metrics.Counter),
+		gauges:   make(map[string]metrics.Gauge),
+		timers:   make(map[string]metrics.Timer),
+	}
+}
+
+func (r *cache) getCounter(name string) (metrics.Counter, bool) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	c, ok := r.counters[name]
+	return c, ok
+}
+
+func (r *cache) getGauge(name string) (metrics.Gauge, bool) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	g, ok := r.gauges[name]
+	return g, ok
+}
+
+func (r *cache) getTimer(name string) (metrics.Timer, bool) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	t, ok := r.timers[name]
+	return t, ok
+}
+
+func (r *cache) setCounter(name string, c metrics.Counter) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.counters[name] = c
+}
+
+func (r *cache) setGauge(name string, g metrics.Gauge) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.gauges[name] = g
+}
+
+func (r *cache) setTimer(name string, t metrics.Timer) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.timers[name] = t
+}

--- a/metrics/adapters/cache.go
+++ b/metrics/adapters/cache.go
@@ -35,41 +35,35 @@ func newCache() *cache {
 	}
 }
 
-func (r *cache) getCounter(name string) (metrics.Counter, bool) {
+func (r *cache) getOrSetCounter(name string, create func() metrics.Counter) metrics.Counter {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	c, ok := r.counters[name]
-	return c, ok
+	if !ok {
+		c = create()
+		r.counters[name] = c
+	}
+	return c
 }
 
-func (r *cache) getGauge(name string) (metrics.Gauge, bool) {
+func (r *cache) getOrSetGauge(name string, create func() metrics.Gauge) metrics.Gauge {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	g, ok := r.gauges[name]
-	return g, ok
+	if !ok {
+		g = create()
+		r.gauges[name] = g
+	}
+	return g
 }
 
-func (r *cache) getTimer(name string) (metrics.Timer, bool) {
+func (r *cache) getOrSetTimer(name string, create func() metrics.Timer) metrics.Timer {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	t, ok := r.timers[name]
-	return t, ok
-}
-
-func (r *cache) setCounter(name string, c metrics.Counter) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	r.counters[name] = c
-}
-
-func (r *cache) setGauge(name string, g metrics.Gauge) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	r.gauges[name] = g
-}
-
-func (r *cache) setTimer(name string, t metrics.Timer) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	r.timers[name] = t
+	if !ok {
+		t = create()
+		r.timers[name] = t
+	}
+	return t
 }

--- a/metrics/adapters/cache_test.go
+++ b/metrics/adapters/cache_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+func TestCache(t *testing.T) {
+	f := metrics.NewLocalFactory(100 * time.Second)
+	c1 := f.Counter("x", nil)
+	g1 := f.Gauge("y", nil)
+	t1 := f.Timer("z", nil)
+
+	c := newCache()
+
+	_, ok := c.getCounter("x")
+	assert.False(t, ok)
+	_, ok = c.getGauge("y")
+	assert.False(t, ok)
+	_, ok = c.getTimer("z")
+	assert.False(t, ok)
+
+	c.setCounter("x", c1)
+	c.setGauge("y", g1)
+	c.setTimer("z", t1)
+
+	c2, ok := c.getCounter("x")
+	assert.True(t, ok)
+	assert.Equal(t, c1, c2)
+	g2, ok := c.getGauge("y")
+	assert.True(t, ok)
+	assert.Equal(t, g1, g2)
+	t2, ok := c.getTimer("z")
+	assert.True(t, ok)
+	assert.Equal(t, t1, t2)
+}

--- a/metrics/adapters/cache_test.go
+++ b/metrics/adapters/cache_test.go
@@ -30,24 +30,17 @@ func TestCache(t *testing.T) {
 
 	c := newCache()
 
-	_, ok := c.getCounter("x")
-	assert.False(t, ok)
-	_, ok = c.getGauge("y")
-	assert.False(t, ok)
-	_, ok = c.getTimer("z")
-	assert.False(t, ok)
-
-	c.setCounter("x", c1)
-	c.setGauge("y", g1)
-	c.setTimer("z", t1)
-
-	c2, ok := c.getCounter("x")
-	assert.True(t, ok)
+	c2 := c.getOrSetCounter("x", func() metrics.Counter { return c1 })
 	assert.Equal(t, c1, c2)
-	g2, ok := c.getGauge("y")
-	assert.True(t, ok)
+	g2 := c.getOrSetGauge("y", func() metrics.Gauge { return g1 })
 	assert.Equal(t, g1, g2)
-	t2, ok := c.getTimer("z")
-	assert.True(t, ok)
+	t2 := c.getOrSetTimer("z", func() metrics.Timer { return t1 })
 	assert.Equal(t, t1, t2)
+
+	c3 := c.getOrSetCounter("x", func() metrics.Counter { panic("c1") })
+	assert.Equal(t, c1, c3)
+	g3 := c.getOrSetGauge("y", func() metrics.Gauge { panic("g1") })
+	assert.Equal(t, g1, g3)
+	t3 := c.getOrSetTimer("z", func() metrics.Timer { panic("t1") })
+	assert.Equal(t, t1, t3)
 }

--- a/metrics/adapters/factory.go
+++ b/metrics/adapters/factory.go
@@ -65,35 +65,23 @@ type factory struct {
 
 func (f *factory) Counter(name string, tags map[string]string) metrics.Counter {
 	fullName, fullTags, key := f.getKey(name, tags)
-	c, ok := f.cache.getCounter(key)
-	if ok {
-		return c
-	}
-	c = f.factory.Counter(fullName, fullTags)
-	f.cache.setCounter(key, c)
-	return c
+	return f.cache.getOrSetCounter(key, func() metrics.Counter {
+		return f.factory.Counter(fullName, fullTags)
+	})
 }
 
 func (f *factory) Gauge(name string, tags map[string]string) metrics.Gauge {
 	fullName, fullTags, key := f.getKey(name, tags)
-	g, ok := f.cache.getGauge(key)
-	if ok {
-		return g
-	}
-	g = f.factory.Gauge(fullName, fullTags)
-	f.cache.setGauge(key, g)
-	return g
+	return f.cache.getOrSetGauge(key, func() metrics.Gauge {
+		return f.factory.Gauge(fullName, fullTags)
+	})
 }
 
 func (f *factory) Timer(name string, tags map[string]string) metrics.Timer {
 	fullName, fullTags, key := f.getKey(name, tags)
-	t, ok := f.cache.getTimer(key)
-	if ok {
-		return t
-	}
-	t = f.factory.Timer(fullName, fullTags)
-	f.cache.setTimer(key, t)
-	return t
+	return f.cache.getOrSetTimer(key, func() metrics.Timer {
+		return f.factory.Timer(fullName, fullTags)
+	})
 }
 
 func (f *factory) Namespace(name string, tags map[string]string) metrics.Factory {

--- a/metrics/adapters/factory.go
+++ b/metrics/adapters/factory.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import (
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+// FactoryWithTags creates metrics with fully qualified name and tags.
+type FactoryWithTags interface {
+	Counter(name string, tags map[string]string) metrics.Counter
+	Gauge(name string, tags map[string]string) metrics.Gauge
+	Timer(name string, tags map[string]string) metrics.Timer
+}
+
+// Options affect how the adapter factory behaves.
+type Options struct {
+	ScopeSep string
+	TagsSep  string
+	TagKVSep string
+}
+
+func defaultOptions(options Options) Options {
+	o := options
+	if o.ScopeSep == "" {
+		o.ScopeSep = "."
+	}
+	if o.TagsSep == "" {
+		o.TagsSep = "."
+	}
+	if o.TagKVSep == "" {
+		o.TagKVSep = "_"
+	}
+	return o
+}
+
+// WrapFactoryWithTags creates a real metrics.Factory that supports subscopes.
+func WrapFactoryWithTags(f FactoryWithTags, options Options) metrics.Factory {
+	return &factory{
+		Options: defaultOptions(options),
+		factory: f,
+		cache:   newCache(),
+	}
+}
+
+type factory struct {
+	Options
+	factory FactoryWithTags
+	scope   string
+	tags    map[string]string
+	cache   *cache
+}
+
+func (f *factory) Counter(name string, tags map[string]string) metrics.Counter {
+	fullName, fullTags, key := f.getKey(name, tags)
+	c, ok := f.cache.getCounter(key)
+	if ok {
+		return c
+	}
+	c = f.factory.Counter(fullName, fullTags)
+	f.cache.setCounter(key, c)
+	return c
+}
+
+func (f *factory) Gauge(name string, tags map[string]string) metrics.Gauge {
+	fullName, fullTags, key := f.getKey(name, tags)
+	g, ok := f.cache.getGauge(key)
+	if ok {
+		return g
+	}
+	g = f.factory.Gauge(fullName, fullTags)
+	f.cache.setGauge(key, g)
+	return g
+}
+
+func (f *factory) Timer(name string, tags map[string]string) metrics.Timer {
+	fullName, fullTags, key := f.getKey(name, tags)
+	t, ok := f.cache.getTimer(key)
+	if ok {
+		return t
+	}
+	t = f.factory.Timer(fullName, fullTags)
+	f.cache.setTimer(key, t)
+	return t
+}
+
+func (f *factory) Namespace(name string, tags map[string]string) metrics.Factory {
+	return &factory{
+		cache:   f.cache,
+		scope:   f.subScope(name),
+		tags:    f.mergeTags(tags),
+		factory: f.factory,
+		Options: f.Options,
+	}
+}
+
+func (f *factory) getKey(name string, tags map[string]string) (fullName string, fullTags map[string]string, key string) {
+	fullName = f.subScope(name)
+	fullTags = f.mergeTags(tags)
+	key = metrics.GetKey(fullName, fullTags, f.TagsSep, f.TagKVSep)
+	return
+}
+
+func (f *factory) mergeTags(tags map[string]string) map[string]string {
+	ret := make(map[string]string, len(f.tags)+len(tags))
+	for k, v := range f.tags {
+		ret[k] = v
+	}
+	for k, v := range tags {
+		ret[k] = v
+	}
+	return ret
+}
+
+func (f *factory) subScope(name string) string {
+	if f.scope == "" {
+		return name
+	}
+	if name == "" {
+		return f.scope
+	}
+	return f.scope + f.ScopeSep + name
+}

--- a/metrics/adapters/factory_test.go
+++ b/metrics/adapters/factory_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	o := defaultOptions(Options{})
+	assert.Equal(t, ".", o.ScopeSep)
+	assert.Equal(t, ".", o.TagsSep)
+	assert.Equal(t, "_", o.TagKVSep)
+}
+
+func TestSubScope(t *testing.T) {
+	f := &factory{
+		Options: defaultOptions(Options{}),
+	}
+	assert.Equal(t, "", f.subScope(""))
+	assert.Equal(t, "x", f.subScope("x"))
+	f.scope = "x"
+	assert.Equal(t, "x", f.subScope(""))
+	assert.Equal(t, "x.y", f.subScope("y"))
+}
+
+func TestFactory(t *testing.T) {
+	var (
+		counterPrefix = "counter_"
+		gaugePrefix   = "gauge_"
+		timerPrefix   = "timer_"
+
+		tagsA = map[string]string{"a": "b"}
+		tagsX = map[string]string{"x": "y"}
+	)
+
+	testCases := []struct {
+		name            string
+		tags            map[string]string
+		namespace       string
+		nsTags          map[string]string
+		fullName        string
+		expectedCounter string
+	}{
+		{name: "x", fullName: "%sx"},
+		{tags: tagsX, fullName: "%s.x_y"},
+		{name: "x", tags: tagsA, fullName: "%sx.a_b"},
+		{namespace: "y", fullName: "y.%s"},
+		{nsTags: tagsA, fullName: "%s.a_b"},
+		{namespace: "y", nsTags: tagsX, fullName: "y.%s.x_y"},
+		{name: "x", namespace: "y", nsTags: tagsX, fullName: "y.%sx.x_y"},
+		{name: "x", tags: tagsX, namespace: "y", nsTags: tagsX, fullName: "y.%sx.x_y", expectedCounter: "84"},
+		{name: "x", tags: tagsA, namespace: "y", nsTags: tagsX, fullName: "y.%sx.a_b.x_y"},
+		{name: "x", tags: tagsX, namespace: "y", nsTags: tagsA, fullName: "y.%sx.a_b.x_y", expectedCounter: "84"},
+	}
+	local := metrics.NewLocalFactory(100 * time.Second)
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			if testCase.expectedCounter == "" {
+				testCase.expectedCounter = "42"
+			}
+			ff := &fakeTagless{factory: local}
+			f := WrapFactoryWithoutTags(ff, Options{})
+			if testCase.namespace != "" || testCase.nsTags != nil {
+				f = f.Namespace(testCase.namespace, testCase.nsTags)
+			}
+			counter := f.Counter(counterPrefix+testCase.name, testCase.tags)
+			gauge := f.Gauge(gaugePrefix+testCase.name, testCase.tags)
+			timer := f.Timer(timerPrefix+testCase.name, testCase.tags)
+
+			assert.Equal(t, counter, f.Counter(counterPrefix+testCase.name, testCase.tags))
+			assert.Equal(t, gauge, f.Gauge(gaugePrefix+testCase.name, testCase.tags))
+			assert.Equal(t, timer, f.Timer(timerPrefix+testCase.name, testCase.tags))
+
+			assert.Equal(t, fmt.Sprintf(testCase.fullName, counterPrefix), ff.counter)
+			assert.Equal(t, fmt.Sprintf(testCase.fullName, gaugePrefix), ff.gauge)
+			assert.Equal(t, fmt.Sprintf(testCase.fullName, timerPrefix), ff.timer)
+		})
+	}
+}
+
+type fakeTagless struct {
+	factory metrics.Factory
+	counter string
+	gauge   string
+	timer   string
+}
+
+func (f *fakeTagless) Counter(name string) metrics.Counter {
+	f.counter = name
+	return f.factory.Counter(name, nil)
+}
+
+func (f *fakeTagless) Gauge(name string) metrics.Gauge {
+	f.gauge = name
+	return f.factory.Gauge(name, nil)
+}
+
+func (f *fakeTagless) Timer(name string) metrics.Timer {
+	f.timer = name
+	return f.factory.Timer(name, nil)
+}

--- a/metrics/adapters/tagless.go
+++ b/metrics/adapters/tagless.go
@@ -16,7 +16,8 @@ package adapters
 
 import "github.com/uber/jaeger-lib/metrics"
 
-// FactoryWithoutTags creates metrics with fully qualified name and tags.
+// FactoryWithoutTags creates metrics based on name only, without tags.
+// Suitable for integrating with statsd-like backends that don't support tags.
 type FactoryWithoutTags interface {
 	Counter(name string) metrics.Counter
 	Gauge(name string) metrics.Gauge

--- a/metrics/adapters/tagless.go
+++ b/metrics/adapters/tagless.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters
+
+import "github.com/uber/jaeger-lib/metrics"
+
+// FactoryWithoutTags creates metrics with fully qualified name and tags.
+type FactoryWithoutTags interface {
+	Counter(name string) metrics.Counter
+	Gauge(name string) metrics.Gauge
+	Timer(name string) metrics.Timer
+}
+
+// WrapFactoryWithoutTags creates a real metrics.Factory that supports subscopes.
+func WrapFactoryWithoutTags(f FactoryWithoutTags, options Options) metrics.Factory {
+	return WrapFactoryWithTags(
+		&tagless{
+			Options: defaultOptions(options),
+			factory: f,
+		},
+		options,
+	)
+}
+
+// tagless implements FactoryWithTags
+type tagless struct {
+	Options
+	factory FactoryWithoutTags
+}
+
+func (f *tagless) Counter(name string, tags map[string]string) metrics.Counter {
+	fullName := f.getFullName(name, tags)
+	return f.factory.Counter(fullName)
+}
+
+func (f *tagless) Gauge(name string, tags map[string]string) metrics.Gauge {
+	fullName := f.getFullName(name, tags)
+	return f.factory.Gauge(fullName)
+}
+
+func (f *tagless) Timer(name string, tags map[string]string) metrics.Timer {
+	fullName := f.getFullName(name, tags)
+	return f.factory.Timer(fullName)
+}
+
+func (f *tagless) getFullName(name string, tags map[string]string) string {
+	return metrics.GetKey(name, tags, f.TagsSep, f.TagKVSep)
+}

--- a/metrics/expvar/factory.go
+++ b/metrics/expvar/factory.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expvar
+
+import (
+	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/adapters"
+	xkit "github.com/uber/jaeger-lib/metrics/go-kit"
+	"github.com/uber/jaeger-lib/metrics/go-kit/expvar"
+)
+
+// NewFactory creates a new metrics factory using go-kit expvar package.
+// buckets is the number of buckets to be used in histograms.
+func NewFactory(buckets int) metrics.Factory {
+	return adapters.WrapFactoryWithoutTags(
+		&factory{
+			factory: expvar.NewFactory(buckets),
+		},
+		adapters.Options{},
+	)
+}
+
+type factory struct {
+	factory xkit.Factory
+}
+
+func (f *factory) Counter(name string) metrics.Counter {
+	return xkit.NewCounter(f.factory.Counter(name))
+}
+
+func (f *factory) Gauge(name string) metrics.Gauge {
+	return xkit.NewGauge(f.factory.Gauge(name))
+}
+
+func (f *factory) Timer(name string) metrics.Timer {
+	return xkit.NewTimer(f.factory.Histogram(name))
+}

--- a/metrics/expvar/factory_test.go
+++ b/metrics/expvar/factory_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expvar
+
+import (
+	"expvar"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	id            = time.Now().UnixNano()
+	prefix        = fmt.Sprintf("test_%d", id)
+	counterPrefix = prefix + "_counter_"
+	gaugePrefix   = prefix + "_gauge_"
+	timerPrefix   = prefix + "_timer_"
+
+	tagsA = map[string]string{"a": "b"}
+	tagsX = map[string]string{"x": "y"}
+)
+
+func TestFactory(t *testing.T) {
+	testCases := []struct {
+		name            string
+		tags            map[string]string
+		namespace       string
+		nsTags          map[string]string
+		fullName        string
+		expectedCounter string
+	}{
+		{name: "x", fullName: "%sx"},
+		{tags: tagsX, fullName: "%s.x_y"},
+		{name: "x", tags: tagsA, fullName: "%sx.a_b"},
+		{namespace: "y", fullName: "y.%s"},
+		{nsTags: tagsA, fullName: "%s.a_b"},
+		{namespace: "y", nsTags: tagsX, fullName: "y.%s.x_y"},
+		{name: "x", namespace: "y", nsTags: tagsX, fullName: "y.%sx.x_y"},
+		{name: "x", tags: tagsX, namespace: "y", nsTags: tagsX, fullName: "y.%sx.x_y", expectedCounter: "84"},
+		{name: "x", tags: tagsA, namespace: "y", nsTags: tagsX, fullName: "y.%sx.a_b.x_y"},
+		{name: "x", tags: tagsX, namespace: "y", nsTags: tagsA, fullName: "y.%sx.a_b.x_y", expectedCounter: "84"},
+	}
+	f := NewFactory(2)
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			if testCase.expectedCounter == "" {
+				testCase.expectedCounter = "42"
+			}
+			ff := f
+			if testCase.namespace != "" || testCase.nsTags != nil {
+				ff = f.Namespace(testCase.namespace, testCase.nsTags)
+			}
+			counter := ff.Counter(counterPrefix+testCase.name, testCase.tags)
+			gauge := ff.Gauge(gaugePrefix+testCase.name, testCase.tags)
+			timer := ff.Timer(timerPrefix+testCase.name, testCase.tags)
+
+			// register second time, should not panic
+			ff.Counter(counterPrefix+testCase.name, testCase.tags)
+			ff.Gauge(gaugePrefix+testCase.name, testCase.tags)
+			ff.Timer(timerPrefix+testCase.name, testCase.tags)
+
+			counter.Inc(42)
+			gauge.Update(42)
+			timer.Record(42 * time.Millisecond)
+
+			assertExpvar(t, fmt.Sprintf(testCase.fullName, counterPrefix), testCase.expectedCounter)
+			assertExpvar(t, fmt.Sprintf(testCase.fullName, gaugePrefix), "42")
+			assertExpvar(t, fmt.Sprintf(testCase.fullName, timerPrefix)+".p99", "0.042")
+		})
+	}
+}
+
+func assertExpvar(t *testing.T, fullName string, value string) {
+	var found expvar.KeyValue
+	expvar.Do(func(kv expvar.KeyValue) {
+		if kv.Key == fullName {
+			found = kv
+		}
+	})
+	if !assert.Equal(t, fullName, found.Key) {
+		expvar.Do(func(kv expvar.KeyValue) {
+			if strings.HasPrefix(kv.Key, prefix) {
+				// t.Log(kv)
+			}
+		})
+		return
+	}
+	assert.Equal(t, value, found.Value.String(), fullName)
+}

--- a/metrics/go-kit/expvar/factory.go
+++ b/metrics/go-kit/expvar/factory.go
@@ -23,6 +23,14 @@ import (
 
 // NewFactory creates a new metrics factory using go-kit expvar package.
 // buckets is the number of buckets to be used in histograms.
+//
+// Deprecated: the recommended way is to use metrics/expvar module:
+//
+//	"github.com/uber/jaeger-lib/metrics/expvar"
+//
+//	var numBuckets = 10
+//	var metricsFactory = expvar.NewFactory(numBuckets)
+//
 func NewFactory(buckets int) xkit.Factory {
 	return factory{
 		buckets: buckets,

--- a/metrics/go-kit/prometheus/factory.go
+++ b/metrics/go-kit/prometheus/factory.go
@@ -32,6 +32,17 @@ var normalizer = strings.NewReplacer(
 // NewFactory creates a new metrics factory using go-kit prometheus package.
 // buckets define the buckets into which histogram observations are counted.
 // If buckets == nil, the default value prometheus.DefBuckets is used.
+//
+// Deprecated: the recommended way is to use metrics/prometheus module:
+//
+//	import (
+//		"github.com/prometheus/client_golang/prometheus"
+//		xprom "github.com/uber/jaeger-lib/metrics/prometheus"
+//	)
+//
+//	registry := prometheus.NewPedanticRegistry()
+//	factory := xprom.New(xprom.WithRegisterer(registry))
+//
 func NewFactory(namespace, subsystem string, buckets []float64) xkit.Factory {
 	return &factory{
 		namespace: namespace,

--- a/metrics/prometheus/cache.go
+++ b/metrics/prometheus/cache.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// vectorCache is used to avoid creating Prometheus vectors with the same set of labels more than once.
 type vectorCache struct {
 	registerer prometheus.Registerer
 	lock       sync.Mutex


### PR DESCRIPTION
Required for https://github.com/jaegertracing/jaeger/issues/716

Add a new module `metrics/adapters` that provide caching of the created metrics objects and the common functionality of managing namespaces and flattening tags into metric id string.