### PR TITLE
Use an interface instead of a concrete type

### DIFF
--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -165,8 +165,12 @@ func (g *gauge) Update(v int64) {
 	g.gauge.Set(float64(v))
 }
 
+type observer interface {
+	Observe(v float64)
+}
+
 type timer struct {
-	histogram prometheus.Observer
+	histogram observer
 }
 
 func (t *timer) Record(v time.Duration) {

--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -166,7 +166,7 @@ func (g *gauge) Update(v int64) {
 }
 
 type timer struct {
-	histogram prometheus.Histogram
+	histogram prometheus.Observer
 }
 
 func (t *timer) Record(v time.Duration) {


### PR DESCRIPTION
I am using the following versions:
```yaml
- package: github.com/prometheus/client_golang
  version: ~0.9.0-pre1
- package: github.com/uber/jaeger-client-go
  version: ^2.12.0
# only in my glide.lock file
- name: github.com/uber/jaeger-lib
  version: 4267858c0679cd4e47cefed8d7f70fd386cfb567
```

If we use a histogram and try to create a new tracer (using `jaeger-client-go`) with metrics, for example:

```Go
        var reg prometheus.Registerer
        // set the value of reg to some Prometheus registry here
	factory := jaegerprom.New(jaegerprom.WithRegisterer(reg))
	tracer, closer, err := config.New(appName, jaegercfg.Metrics(factory))
```

I get the following error:

```bash
vendor/github.com/uber/jaeger-lib/metrics/prometheus/factory.go:143:12: cannot use hv.WithLabelValues(f.tagsAsLabelValues(labelNames, tags)...) (type prometheus.Observer) as type prometheus.Histogram in field value:
	prometheus.Observer does not implement prometheus.Histogram (missing Collect method)
```

This PR fixes this issue, while all unit tests still pass. It just replaces a concrete type with a single-method interface.