### PR TITLE
metrics: break out local backend into metrics/local

### DIFF
--- a/metrics/adapters/cache_test.go
+++ b/metrics/adapters/cache_test.go
@@ -19,11 +19,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/testutils/metricstest"
 )
 
 func TestCache(t *testing.T) {
-	f := metrics.NewLocalFactory(100 * time.Second)
+	f := metricstest.NewFactory(100 * time.Second)
 	c1 := f.Counter("x", nil)
 	g1 := f.Gauge("y", nil)
 	t1 := f.Timer("z", nil)

--- a/metrics/adapters/factory_test.go
+++ b/metrics/adapters/factory_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/testutils/metricstest"
 )
 
 func TestDefaultOptions(t *testing.T) {
@@ -70,7 +71,7 @@ func TestFactory(t *testing.T) {
 		{name: "x", tags: tagsA, namespace: "y", nsTags: tagsX, fullName: "y.%sx.a_b.x_y"},
 		{name: "x", tags: tagsX, namespace: "y", nsTags: tagsA, fullName: "y.%sx.a_b.x_y", expectedCounter: "84"},
 	}
-	local := metrics.NewLocalFactory(100 * time.Second)
+	local := metricstest.NewFactory(100 * time.Second)
 	for _, testCase := range testCases {
 		t.Run("", func(t *testing.T) {
 			if testCase.expectedCounter == "" {

--- a/metrics/keys.go
+++ b/metrics/keys.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sort"
+)
+
+// GetKey converts name+tags into a single string of the form
+// "name|tag1=value1|...|tagN=valueN", where tag names are
+// sorted alphabetically.
+func GetKey(name string, tags map[string]string, tagsSep string, tagKVSep string) string {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	key := name
+	for _, k := range keys {
+		key = key + tagsSep + k + tagKVSep + tags[k]
+	}
+	return key
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -21,19 +21,24 @@ import (
 )
 
 // Init initializes the passed in metrics and initializes its fields using the passed in factory.
-func Init(metrics interface{}, factory Factory, globalTags map[string]string) {
-	if err := initMetrics(metrics, factory, globalTags); err != nil {
-		panic(err.Error())
-	}
-}
-
-// initMetrics uses reflection to initialize a struct containing metrics fields
+//
+// It uses reflection to initialize a struct containing metrics fields
 // by assigning new Counter/Gauge/Timer values with the metric name retrieved
 // from the `metric` tag and stats tags retrieved from the `tags` tag.
 //
 // Note: all fields of the struct must be exported, have a `metric` tag, and be
 // of type Counter or Gauge or Timer.
-func initMetrics(m interface{}, factory Factory, globalTags map[string]string) error {
+//
+// Errors during Init lead to a panic.
+func Init(metrics interface{}, factory Factory, globalTags map[string]string) {
+	if err := InitOrError(metrics, factory, globalTags); err != nil {
+		panic(err.Error())
+	}
+}
+
+// InitOrError does the same as Init, but returns an error instead of
+// panicking.
+func InitOrError(m interface{}, factory Factory, globalTags map[string]string) error {
 	// Allow user to opt out of reporting metrics by passing in nil.
 	if factory == nil {
 		factory = NullFactory

--- a/metrics/multi/multi_test.go
+++ b/metrics/multi/multi_test.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger-lib/metrics/testutils"
+	"github.com/uber/jaeger-lib/metrics/testutils/metricstest"
 )
 
 var _ metrics.Factory = &Factory{} // API check
 
 func TestMultiFactory(t *testing.T) {
-	f1 := metrics.NewLocalFactory(time.Second)
-	f2 := metrics.NewLocalFactory(time.Second)
+	f1 := metricstest.NewFactory(time.Second)
+	f2 := metricstest.NewFactory(time.Second)
 	multi1 := New(f1, f2)
 	multi2 := multi1.Namespace("ns2", nil)
 	tags := map[string]string{"x": "y"}
@@ -21,11 +21,11 @@ func TestMultiFactory(t *testing.T) {
 	multi2.Gauge("gauge", tags).Update(42)
 	multi2.Timer("timer", tags).Record(42 * time.Millisecond)
 
-	for _, f := range []*metrics.LocalFactory{f1, f2} {
-		testutils.AssertCounterMetrics(t, f,
-			testutils.ExpectedMetric{Name: "ns2.counter", Tags: tags, Value: 42})
-		testutils.AssertGaugeMetrics(t, f,
-			testutils.ExpectedMetric{Name: "ns2.gauge", Tags: tags, Value: 42})
+	for _, f := range []*metricstest.Factory{f1, f2} {
+		metricstest.AssertCounterMetrics(t, f,
+			metricstest.ExpectedMetric{Name: "ns2.counter", Tags: tags, Value: 42})
+		metricstest.AssertGaugeMetrics(t, f,
+			metricstest.ExpectedMetric{Name: "ns2.gauge", Tags: tags, Value: 42})
 		_, g := f.Snapshot()
 		assert.EqualValues(t, 43, g["ns2.timer|x=y.P99"])
 	}

--- a/metrics/testutils/metricstest/local_test.go
+++ b/metrics/testutils/metricstest/local_test.go
@@ -1,4 +1,4 @@
-package metrics
+package metricstest
 
 import (
 	"testing"
@@ -13,7 +13,7 @@ func TestLocalMetrics(t *testing.T) {
 		"x": "y",
 	}
 
-	f := NewLocalFactory(0)
+	f := NewFactory(0)
 	defer f.Stop()
 	f.Counter("my-counter", tags).Inc(4)
 	f.Counter("my-counter", tags).Inc(6)
@@ -87,7 +87,7 @@ func TestLocalMetricsInterval(t *testing.T) {
 	const maxChecks = 2 * relativeCheckFrequency
 	checkInterval := (refreshInterval * relativeCheckFrequency) / maxChecks
 
-	f := NewLocalFactory(refreshInterval)
+	f := NewFactory(refreshInterval)
 	defer f.Stop()
 
 	f.Timer("timer", nil).Record(1)
@@ -97,7 +97,7 @@ func TestLocalMetricsInterval(t *testing.T) {
 	f.tm.Unlock()
 	assert.NotNil(t, timer)
 
-	// timer.hist.Current is modified on every Rotate(), which is called by LocalBackend after every refreshInterval
+	// timer.hist.Current is modified on every Rotate(), which is called by Backend after every refreshInterval
 	getCurr := func() interface{} {
 		timer.Lock()
 		defer timer.Unlock()

--- a/metrics/testutils/metricstest/metricstest.go
+++ b/metrics/testutils/metricstest/metricstest.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testutils
+package metricstest
 
 import (
 	"testing"
@@ -32,13 +32,13 @@ type ExpectedMetric struct {
 // TODO do something similar for Timers
 
 // AssertCounterMetrics checks if counter metrics exist.
-func AssertCounterMetrics(t *testing.T, f *metrics.LocalFactory, expectedMetrics ...ExpectedMetric) {
+func AssertCounterMetrics(t *testing.T, f *Factory, expectedMetrics ...ExpectedMetric) {
 	counters, _ := f.Snapshot()
 	assertMetrics(t, counters, expectedMetrics...)
 }
 
 // AssertGaugeMetrics checks if gauge metrics exist.
-func AssertGaugeMetrics(t *testing.T, f *metrics.LocalFactory, expectedMetrics ...ExpectedMetric) {
+func AssertGaugeMetrics(t *testing.T, f *Factory, expectedMetrics ...ExpectedMetric) {
 	_, gauges := f.Snapshot()
 	assertMetrics(t, gauges, expectedMetrics...)
 }

--- a/metrics/testutils/metricstest/metricstest_test.go
+++ b/metrics/testutils/metricstest/metricstest_test.go
@@ -1,13 +1,11 @@
-package testutils
+package metricstest
 
 import (
 	"testing"
-
-	"github.com/uber/jaeger-lib/metrics"
 )
 
 func TestAssertMetrics(t *testing.T) {
-	f := metrics.NewLocalFactory(0)
+	f := NewFactory(0)
 	tags := map[string]string{"key": "value"}
 	f.IncCounter("counter", tags, 1)
 	f.UpdateGauge("gauge", tags, 11)


### PR DESCRIPTION
## Which problem is this PR solving?
- Applications using jaeger-client-go pull in the local backend although it is unused
  and more importantly, they also depend on the unmaintained
  https://github.com/codahale/hdrhistogram

  This can raise red flags when trying to use jaeger-client-go in organizations
  were dependencies are closely scrutinized.

- This PR does *not* remove the dependency on hdrhistogram and thus
  does not solve #32.

## Short description of the changes

-   Now the local backend is in a new metrics/local package that is not
    pulled in via the client API. Beware that this an API break because
    "metrics" no longer has the same functions.
    
-  To minimize the API change, GetKey() is kept in "metrics" because it
    doesn't depend on the local backend.
    
-  To break a dependency cycle (metrics -> local -> metrics),
    test_metrics.go has to be in a metrics_test package and do black-box
    testing. This in turn made it necessary to export initMetrics as part
    of the metrics API. It was renamed to InitWithError and documented
    accordingly to emphasize that it has the same functionality and only
    differs in the return value.
    
    Unfortunately the logic is now backwards compared to other packages
    (regexp.Compile returns an error, regexp.MustCompile panics), but
    preserving API compatibility with older releases is more important.

