### PR TITLE
Add _total suffix for counters reported to prometheus

### DIFF
--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -126,7 +126,7 @@ func newFactory(parent *Factory, scope string, tags map[string]string) *Factory 
 
 // Counter implements Counter of metrics.Factory.
 func (f *Factory) Counter(name string, tags map[string]string) metrics.Counter {
-	name = f.subScope(name)
+	name = counterNamingConvention(f.subScope(name))
 	tags = f.mergeTags(tags)
 	labelNames := f.tagNames(tags)
 	opts := prometheus.CounterOpts{
@@ -243,4 +243,11 @@ func (f *Factory) tagsAsLabelValues(labels []string, tags map[string]string) []s
 		ret = append(ret, tags[l])
 	}
 	return ret
+}
+
+func counterNamingConvention(name string) string {
+	if !strings.HasSuffix(name, "_total") {
+		name += "_total"
+	}
+	return name
 }

--- a/metrics/prometheus/factory_test.go
+++ b/metrics/prometheus/factory_test.go
@@ -41,7 +41,7 @@ func TestSeparator(t *testing.T) {
 	c1.Inc(1)
 	snapshot, err := registry.Gather()
 	require.NoError(t, err)
-	m1 := findMetric(t, snapshot, "bender:rodriguez", map[string]string{"a": "b"})
+	m1 := findMetric(t, snapshot, "bender:rodriguez_total", map[string]string{"a": "b"})
 	assert.EqualValues(t, 1, m1.GetCounter().GetValue(), "%+v", m1)
 }
 
@@ -63,10 +63,10 @@ func TestCounter(t *testing.T) {
 	snapshot, err := registry.Gather()
 	require.NoError(t, err)
 
-	m1 := findMetric(t, snapshot, "bender_rodriguez", map[string]string{"a": "b", "x": "y"})
+	m1 := findMetric(t, snapshot, "bender_rodriguez_total", map[string]string{"a": "b", "x": "y"})
 	assert.EqualValues(t, 3, m1.GetCounter().GetValue(), "%+v", m1)
 
-	m2 := findMetric(t, snapshot, "bender_rodriguez", map[string]string{"a": "b", "x": "z"})
+	m2 := findMetric(t, snapshot, "bender_rodriguez_total", map[string]string{"a": "b", "x": "z"})
 	assert.EqualValues(t, 7, m2.GetCounter().GetValue(), "%+v", m2)
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
As discussed in the [prometheus documentation](https://prometheus.io/docs/practices/naming/#metric-names), "an accumulating count has total as a suffix".

## Short description of the changes
If the counter does not have the `_total` suffix, then it will be added.

This change will also be required to bring the Go tracer inline with the metrics being reported by the Java tracer, which is using the micrometer library that applies a similar transformation on the counter metric names. See https://github.com/jaegertracing/jaeger-client-java/pull/564.

Signed-off-by: Gary Brown <gary@brownuk.com>