### PR TITLE
Upgrade to Go 1.11.1 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ go_import_path: github.com/uber/jaeger-lib
 
 matrix:
   include:
-  - go: 1.7
+  - go: 1.11.1
     env:
     - COVERAGE=true
-  - go: 1.9
+  - go: 1.11.1
     env:
     - TEST=true
-  - go: 1.7
+  - go: 1.11.1
     env:
     - TEST=true
     - USE_DEP=true

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ install-ci: install
 	go get github.com/wadey/gocovmerge
 	go get github.com/mattn/goveralls
 	go get golang.org/x/tools/cmd/cover
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 
 
 .PHONY: test-ci


### PR DESCRIPTION
- Resolves #55.

- Travis changes to use Go 1.11.1.