### PR TITLE
Remove GO15VENDOREXPERIMENT variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ matrix:
     - TEST=true
     - USE_DEP=true
 
-env:
-  global:
-    - GO15VENDOREXPERIMENT=1
-
 install:
   - if [ "$USE_DEP" == true ]; then make install-dep-ci ; else echo 'skipping installing dep'; fi
   - make install-ci

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ ALL_SRC := $(shell find . -name "*.go" | grep -v -e vendor -e thrift-gen \
         -e ".*/_.*" \
         -e ".*/mocks.*")
 
-export GO15VENDOREXPERIMENT=1
-
 GOTEST=go test -v $(RACE)
 GOLINT=golint
 GOVET=go vet


### PR DESCRIPTION
## Which problem is this PR solving?
- Removes GO15VENDOREXPERIMENT variable on development and CI.

## Short description of the changes
- Even at the inception of the project, as this project supports only Go 1.6+ 321ba1b6f06ecca380cf284172eb1ee17e71c37d, we do not need to have `GO15VENDOREXPERIMENT`.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>