### PR TITLE
[fix] updated hdrhistogram dependency to HdrHistogram org repo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,12 +18,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "master"
   digest = "1:4c4c33075b704791d6a7f09dfb55c66769e8a1dc6adf87026292d274fe8ad113"
-  name = "github.com/codahale/hdrhistogram"
+  name = "github.com/HdrHistogram/hdrhistogram-go"
   packages = ["."]
   pruneopts = "UT"
   revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
+  version = "0.9.0"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
@@ -183,7 +183,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/codahale/hdrhistogram",
+    "github.com/HdrHistogram/hdrhistogram-go",
     "github.com/go-kit/kit/log",
     "github.com/go-kit/kit/log/level",
     "github.com/go-kit/kit/metrics",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,8 +3,8 @@
   version = "0.9.0"
 
 [[constraint]]
-  name = "github.com/codahale/hdrhistogram"
-  branch = "master"
+  name = "github.com/HdrHistogram/hdrhistogram-go"
+  version = "0.9.0"
 
 [[constraint]]
   name = "github.com/uber-go/tally"

--- a/glide.lock
+++ b/glide.lock
@@ -5,7 +5,7 @@ imports:
   version: 37c8de3658fcb183f997c4e13e8337516ab753e6
   subpackages:
   - quantile
-- name: github.com/codahale/hdrhistogram
+- name: github.com/HdrHistogram/hdrhistogram-go
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/davecgh/go-spew
   version: d8f796af33cc11cb798c1aaeb27a4ebc5099927d

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/uber/jaeger-lib
 import:
-- package: github.com/codahale/hdrhistogram
+- package: github.com/HdrHistogram/hdrhistogram-go
+  version: '0.9.0'
 - package: github.com/go-kit/kit
   version: '~0.9'
   subpackages:

--- a/metrics/metricstest/local.go
+++ b/metrics/metricstest/local.go
@@ -19,7 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/codahale/hdrhistogram"
+	"github.com/HdrHistogram/hdrhistogram-go"
 	"github.com/uber/jaeger-lib/metrics"
 )
 


### PR DESCRIPTION
The codahale/hdrhistogram repo has been transferred under the github HdrHstogram umbrella with the help from the original author in Sept 2020 (new repo url https://github.com/HdrHistogram/hdrhistogram-go). The main reasons are to group all implementations under the same roof and to provide more active contribution from the community as the original repository was archived several years ago.

Unfortunately such URL change will break go applications that depend on this library directly or indirectly, as discussed here.

The dependency URL should be modified to point to the new repository URL. The tag "v0.9.0" was applied at the point of transfer and will reflect the exact code that was frozen in the original repository.

This PR updates the dependency, thus fixes #81 
