### PR TITLE
Implement fork.Factory

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -164,12 +164,11 @@
   version = "v3.3.12"
 
 [[projects]]
-  digest = "1:abbb7762b4200f8b1d82193dcc02a3d8a62efc0a0ffc8ec4f4e9ef8abf797a9c"
+  digest = "1:dcdd0a1ffcf3a64a4f023d6be5af744e587ce364130f0695cadc1432b5f94610"
   name = "github.com/uber/jaeger-lib"
   packages = [
     "metrics",
     "metrics/adapters",
-    "metrics/expvar",
     "metrics/go-kit",
     "metrics/go-kit/expvar",
     "metrics/metricstest",
@@ -214,7 +213,6 @@
     "github.com/uber-go/tally",
     "github.com/uber/jaeger-lib/metrics",
     "github.com/uber/jaeger-lib/metrics/adapters",
-    "github.com/uber/jaeger-lib/metrics/expvar",
     "github.com/uber/jaeger-lib/metrics/go-kit",
     "github.com/uber/jaeger-lib/metrics/go-kit/expvar",
     "github.com/uber/jaeger-lib/metrics/metricstest",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -164,6 +164,22 @@
   version = "v3.3.12"
 
 [[projects]]
+  digest = "1:abbb7762b4200f8b1d82193dcc02a3d8a62efc0a0ffc8ec4f4e9ef8abf797a9c"
+  name = "github.com/uber/jaeger-lib"
+  packages = [
+    "metrics",
+    "metrics/adapters",
+    "metrics/expvar",
+    "metrics/go-kit",
+    "metrics/go-kit/expvar",
+    "metrics/metricstest",
+    "metrics/prometheus",
+  ]
+  pruneopts = "UT"
+  revision = "a87ae9d84fb038a8d79266298970720be7c80fcd"
+  version = "v2.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:6f104e30a35d62427b90130710ff507d6b9fc95ca76ceafb0025cd2809d93232"
   name = "golang.org/x/sys"
@@ -196,6 +212,13 @@
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/uber-go/tally",
+    "github.com/uber/jaeger-lib/metrics",
+    "github.com/uber/jaeger-lib/metrics/adapters",
+    "github.com/uber/jaeger-lib/metrics/expvar",
+    "github.com/uber/jaeger-lib/metrics/go-kit",
+    "github.com/uber/jaeger-lib/metrics/go-kit/expvar",
+    "github.com/uber/jaeger-lib/metrics/metricstest",
+    "github.com/uber/jaeger-lib/metrics/prometheus",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/metrics/fork/fork.go
+++ b/metrics/fork/fork.go
@@ -1,0 +1,53 @@
+package fork
+
+import "github.com/uber/jaeger-lib/metrics"
+
+// Factory represents a metrics factory that delegates metrics with
+// forkNamespace to forkFactory otherwise - defaultFactory is used.
+type Factory struct {
+	forkNamespace  string
+	forkFactory    metrics.Factory
+	defaultFactory metrics.Factory
+}
+
+// New creates new fork.Factory.
+func New(forkNamespace string, forkFactory, defaultFactory metrics.Factory) metrics.Factory {
+	return &Factory{
+		forkNamespace:  forkNamespace,
+		forkFactory:    forkFactory,
+		defaultFactory: defaultFactory,
+	}
+}
+
+// Gauge implements metrics.Factory interface.
+func (f *Factory) Gauge(options metrics.Options) metrics.Gauge {
+	return f.defaultFactory.Gauge(options)
+}
+
+// Counter implements metrics.Factory interface.
+func (f *Factory) Counter(metric metrics.Options) metrics.Counter {
+	return f.defaultFactory.Counter(metric)
+}
+
+// Timer implements metrics.Factory interface.
+func (f *Factory) Timer(metric metrics.TimerOptions) metrics.Timer {
+	return f.defaultFactory.Timer(metric)
+}
+
+// Histogram implements metrics.Factory interface.
+func (f *Factory) Histogram(metric metrics.HistogramOptions) metrics.Histogram {
+	return f.defaultFactory.Histogram(metric)
+}
+
+// Namespace implements metrics.Factory interface.
+func (f *Factory) Namespace(scope metrics.NSOptions) metrics.Factory {
+	if scope.Name == f.forkNamespace {
+		return f.forkFactory.Namespace(scope)
+	}
+
+	return &Factory{
+		forkNamespace:  f.forkNamespace,
+		forkFactory:    f.forkFactory.Namespace(scope),
+		defaultFactory: f.defaultFactory.Namespace(scope),
+	}
+}

--- a/metrics/fork/fork.go
+++ b/metrics/fork/fork.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fork
 
 import "github.com/uber/jaeger-lib/metrics"

--- a/metrics/fork/fork_test.go
+++ b/metrics/fork/fork_test.go
@@ -39,94 +39,68 @@ func TestForkFactory(t *testing.T) {
 	ff := New(forkNamespace, forkFactory, defaultFactory)
 	ff.Gauge(metrics.Options{
 		Name: "somegauge",
-		Tags: nil,
-		Help: "",
-	}).Update(666)
+	}).Update(42)
 	ff.Counter(metrics.Options{
 		Name: "somecounter",
-		Tags: nil,
-		Help: "",
 	}).Inc(2)
 
 	// Check that metrics are presented in defaultFactory backend
 	defaultFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "somecounter",
-		Tags:  nil,
 		Value: 2,
 	})
 	defaultFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "somegauge",
-		Tags:  nil,
-		Value: 666,
+		Value: 42,
 	})
 
 	// Get default namespaced factory
 	defaultNamespacedFactory := ff.Namespace(metrics.NSOptions{
 		Name: "default",
-		Tags: nil,
 	})
 
 	// Add some metrics
 	defaultNamespacedFactory.Counter(metrics.Options{
 		Name: "somenamespacedcounter",
-		Tags: nil,
-		Help: "",
 	}).Inc(111)
 	defaultNamespacedFactory.Gauge(metrics.Options{
 		Name: "somenamespacedgauge",
-		Tags: nil,
-		Help: "",
 	}).Update(222)
 	defaultNamespacedFactory.Histogram(metrics.HistogramOptions{
-		Name:    "somenamespacedhist",
-		Tags:    nil,
-		Help:    "",
-		Buckets: nil,
+		Name: "somenamespacedhist",
 	}).Record(1)
 	defaultNamespacedFactory.Timer(metrics.TimerOptions{
-		Name:    "somenamespacedtimer",
-		Tags:    nil,
-		Help:    "",
-		Buckets: nil,
+		Name: "somenamespacedtimer",
 	}).Record(time.Millisecond)
 
 	// Check values in default namespaced factory backend
 	defaultFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "default.somenamespacedcounter",
-		Tags:  nil,
 		Value: 111,
 	})
 	defaultFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "default.somenamespacedgauge",
-		Tags:  nil,
 		Value: 222,
 	})
 
 	// Get factory with forkNamespace and add some metrics
 	internalFactory := ff.Namespace(metrics.NSOptions{
 		Name: forkNamespace,
-		Tags: nil,
 	})
 	internalFactory.Gauge(metrics.Options{
 		Name: "someinternalgauge",
-		Tags: nil,
-		Help: "",
 	}).Update(20)
 	internalFactory.Counter(metrics.Options{
 		Name: "someinternalcounter",
-		Tags: nil,
-		Help: "",
 	}).Inc(50)
 
 	// Check that metrics are presented in forkFactory backend
 	forkFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
 		Name:  "internal.someinternalgauge",
-		Tags:  nil,
 		Value: 20,
 	})
 	forkFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
 		Name:  "internal.someinternalcounter",
-		Tags:  nil,
 		Value: 50,
 	})
 }

--- a/metrics/fork/fork_test.go
+++ b/metrics/fork/fork_test.go
@@ -1,0 +1,76 @@
+package fork
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/metricstest"
+)
+
+func TestAPICheck(t *testing.T) {
+	var v interface{} = &Factory{}
+	_, ok := v.(metrics.Factory)
+	assert.True(t, ok)
+}
+
+func TestForkFactory(t *testing.T) {
+	forkNamespace := "internal"
+	forkFactory := metricstest.NewFactory(time.Second)
+	defaultFactory := metricstest.NewFactory(time.Second)
+
+	// Create factory that will delegate namespaced metrics to forkFactory
+	// and add some metrics
+	ff := New(forkNamespace, forkFactory, defaultFactory)
+	ff.Gauge(metrics.Options{
+		Name: "somegauge",
+		Tags: nil,
+		Help: "",
+	}).Update(666)
+	ff.Counter(metrics.Options{
+		Name: "somecounter",
+		Tags: nil,
+		Help: "",
+	}).Inc(2)
+
+	// Check that metrics are presented in defaultFactory backend
+	defaultFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
+		Name:  "somecounter",
+		Tags:  nil,
+		Value: 2,
+	})
+	defaultFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
+		Name:  "somegauge",
+		Tags:  nil,
+		Value: 666,
+	})
+
+	// Get factory with forkNamespace and add some metrics
+	internalFactory := ff.Namespace(metrics.NSOptions{
+		Name: forkNamespace,
+		Tags: nil,
+	})
+	internalFactory.Gauge(metrics.Options{
+		Name: "someinternalgauge",
+		Tags: nil,
+		Help: "",
+	}).Update(20)
+	internalFactory.Counter(metrics.Options{
+		Name: "someinternalcounter",
+		Tags: nil,
+		Help: "",
+	}).Inc(50)
+
+	// Check that metrics are presented in forkFactory backend
+	forkFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
+		Name:  "internal.someinternalgauge",
+		Tags:  nil,
+		Value: 20,
+	})
+	forkFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
+		Name:  "internal.someinternalcounter",
+		Tags:  nil,
+		Value: 50,
+	})
+}

--- a/metrics/fork/fork_test.go
+++ b/metrics/fork/fork_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fork
 
 import (

--- a/metrics/fork/fork_test.go
+++ b/metrics/fork/fork_test.go
@@ -60,6 +60,48 @@ func TestForkFactory(t *testing.T) {
 		Value: 666,
 	})
 
+	// Get default namespaced factory
+	defaultNamespacedFactory := ff.Namespace(metrics.NSOptions{
+		Name: "default",
+		Tags: nil,
+	})
+
+	// Add some metrics
+	defaultNamespacedFactory.Counter(metrics.Options{
+		Name: "somenamespacedcounter",
+		Tags: nil,
+		Help: "",
+	}).Inc(111)
+	defaultNamespacedFactory.Gauge(metrics.Options{
+		Name: "somenamespacedgauge",
+		Tags: nil,
+		Help: "",
+	}).Update(222)
+	defaultNamespacedFactory.Histogram(metrics.HistogramOptions{
+		Name:    "somenamespacedhist",
+		Tags:    nil,
+		Help:    "",
+		Buckets: nil,
+	}).Record(1)
+	defaultNamespacedFactory.Timer(metrics.TimerOptions{
+		Name:    "somenamespacedtimer",
+		Tags:    nil,
+		Help:    "",
+		Buckets: nil,
+	}).Record(time.Millisecond)
+
+	// Check values in default namespaced factory backend
+	defaultFactory.AssertCounterMetrics(t, metricstest.ExpectedMetric{
+		Name:  "default.somenamespacedcounter",
+		Tags:  nil,
+		Value: 111,
+	})
+	defaultFactory.AssertGaugeMetrics(t, metricstest.ExpectedMetric{
+		Name:  "default.somenamespacedgauge",
+		Tags:  nil,
+		Value: 222,
+	})
+
 	// Get factory with forkNamespace and add some metrics
 	internalFactory := ff.Namespace(metrics.NSOptions{
 		Name: forkNamespace,

--- a/metrics/fork/fork_test.go
+++ b/metrics/fork/fork_test.go
@@ -18,16 +18,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/jaeger-lib/metrics"
 	"github.com/uber/jaeger-lib/metrics/metricstest"
 )
 
-func TestAPICheck(t *testing.T) {
-	var v interface{} = &Factory{}
-	_, ok := v.(metrics.Factory)
-	assert.True(t, ok)
-}
+var _ metrics.Factory = (*Factory)(nil)
 
 func TestForkFactory(t *testing.T) {
 	forkNamespace := "internal"


### PR DESCRIPTION
## Which problem is this PR solving?
- Required changes for https://github.com/jaegertracing/jaeger/pull/2496

## Short description of the changes
- Implement fork.Factory that delegates metrics with
specific namespaces to different factory, otherwise
default factory is used.
