### PR TITLE
Apply default buckets in Prometheus Factory

### DIFF
--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -197,12 +197,13 @@ func (f *Factory) Histogram(options metrics.HistogramOptions) metrics.Histogram 
 		help = options.Name
 	}
 	name := f.subScope(options.Name)
+	buckets := f.selectBuckets(options.Buckets)
 	tags := f.mergeTags(options.Tags)
 	labelNames := f.tagNames(tags)
 	opts := prometheus.HistogramOpts{
 		Name:    name,
 		Help:    help,
-		Buckets: options.Buckets,
+		Buckets: buckets,
 	}
 	hv := f.cache.getOrMakeHistogramVec(opts, labelNames)
 	return &histogram{
@@ -291,6 +292,13 @@ func (f *Factory) tagsAsLabelValues(labels []string, tags map[string]string) []s
 		ret = append(ret, tags[l])
 	}
 	return ret
+}
+
+func (f *Factory) selectBuckets(buckets []float64) []float64 {
+	if len(buckets) > 0 {
+		return buckets
+	}
+	return f.buckets
 }
 
 func counterNamingConvention(name string) string {


### PR DESCRIPTION
Signed-off-by: Konstantinos Moraitis <k.moraitis9@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger-lib/issues/89

## Short description of the changes
- The prometheus factory determines which buckets to use when creating a Histogram. 
If the histogram options, provided as arguments, are empty, then the factory uses the default buckets.
