### PR TITLE
Apply default buckets for Timer metric in Prometheus Factory

### DIFF
--- a/metrics/prometheus/factory.go
+++ b/metrics/prometheus/factory.go
@@ -169,12 +169,13 @@ func (f *Factory) Timer(options metrics.TimerOptions) metrics.Timer {
 		help = options.Name
 	}
 	name := f.subScope(options.Name)
+	buckets := f.selectBuckets(asFloatBuckets(options.Buckets))
 	tags := f.mergeTags(options.Tags)
 	labelNames := f.tagNames(tags)
 	opts := prometheus.HistogramOpts{
 		Name:    name,
 		Help:    help,
-		Buckets: asFloatBuckets(options.Buckets),
+		Buckets: buckets,
 	}
 	hv := f.cache.getOrMakeHistogramVec(opts, labelNames)
 	return &timer{


### PR DESCRIPTION
Signed-off-by: Konstantinos Moraitis <k.moraitis9@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- In the same way as the `Histogram` metric in the Prometheus factory (https://github.com/jaegertracing/jaeger-lib/issues/89), we should also consider using the default buckets with the `Timer` metric.

## Short description of the changes
- The prometheus factory determines which buckets to use when creating a Timer.
If the buckets in timer options, provided as arguments, are empty, then the factory uses the default buckets.
